### PR TITLE
Fix links

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
 <p>We hope to create a server which can either act as a more performant drop-in replacement for the vanilla server, or support mods written in Rust. The server side of the project is quite new and doesn't do anything yet.</p>
 
 <ul>
-<li>  <a href="repository">https://github.com/PistonDevelopers/hematite_server</a>
+<li>  <a href="https://github.com/PistonDevelopers/hematite_server">repository</a>
 </li>
 </ul>
 
@@ -52,7 +52,7 @@
 <p>The client uses the <a href="http://www.piston.rs/">Piston</a> and can currently render a “frozen” version of a Minecraft world: you can fly around in it but not interact. Rendering is nearing pixel perfection for blocks. Eventually, we also want to integrate it with the server to provide a real singleplayer mode.</p>
 
 <ul>
-<li>  <a href="repository">https://github.com/PistonDevelopers/hematite</a>
+<li>  <a href="https://github.com/PistonDevelopers/hematite">repository</a>
 </li>
 </ul>
       </section>


### PR DESCRIPTION
I always get the Markdown link syntax wrong.
